### PR TITLE
Updated home page to use an Angular Material sidenav instead of an accordion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engineering-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,2 @@
-<app-banner></app-banner>
-<div class="container mt-5">
-  <app-home></app-home>
-</div>
+<app-home></app-home>
 <app-footer></app-footer>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -19,11 +19,4 @@ describe('AppComponent', () => {
     const app = fixture.componentInstance;
     expect(app.title).toEqual('engineering-tools');
   });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Engineering Toolkit');
-  });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,8 +10,8 @@ import { FooterComponent } from './footer/footer.component';
     BannerComponent,
     FooterComponent,
     RouterModule,
-    HomeComponent,
-  ],
+    HomeComponent
+],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,4 +1,118 @@
 :host {
     display: block;
-    margin-top: 1rem;
-}
+    width: 100%;
+    overflow: hidden;
+  }
+  
+  .home-container {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: calc(100vh - 60px); 
+  }
+  
+  .sidenav-container {
+    flex: 1;
+    width: 100%;
+    height: 100%; 
+  }
+  
+  mat-sidenav {
+    width: 250px;
+    background-color: #f8f8f8;
+    border-right: 1px solid #e0e0e0;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .sidenav-title {
+    padding: 16px;
+    font-size: 24px;
+    font-weight: 500;
+    color: #333;
+    margin: 0;
+    border-bottom: 1px solid #e0e0e0;
+  }
+  
+  mat-sidenav-content {
+    flex: 1;
+    padding: 0;
+    background-color: #ffffff;
+    overflow-y: auto;
+  }
+  
+  .content {
+    padding: 0;
+    height: 100%;
+  }
+  
+  .tool-container {
+    padding: 60px;
+    background-color: #ffffff;
+    border-radius: 5px;
+    height: calc(100% - 40px);
+  }
+  
+  .tool-container h2 {
+    font-size: 32px;
+    margin-bottom: 20px;
+    color: #333;
+  }
+  
+  .nav-label {
+    margin-left: 8px;
+  }
+  
+  .active {
+    background-color: #efefef;
+    color: #3f51b5;
+    border-left: 4px solid #3f51b5;
+  }
+  
+  .no-tools-message {
+    display: flex;
+    align-items: center;
+    padding: 16px;
+    color: #f44336;
+  }
+  
+  .no-tools-message mat-icon {
+    margin-right: 8px;
+  }
+  
+  .no-tools-container {
+    text-align: center;
+    margin-top: 50px;
+    color: #777;
+  }
+  
+  mat-nav-list {
+    padding-top: 0;
+  }
+  
+  mat-nav-list a {
+    font-weight: 400;
+    color: #333;
+    height: 48px;
+    line-height: 48px;
+    padding: 0 16px;
+    text-decoration: none;
+    display: flex;
+    align-items: center;
+    transition: background-color 0.2s ease;
+  }
+  
+  mat-nav-list a:hover {
+    background-color: #efefef;
+  }
+  
+  mat-nav-list a.active {
+    background-color: #ececec;
+    color: #4263eb;
+  }
+  
+  ::ng-deep .mat-drawer-container,
+  ::ng-deep .mat-drawer-content,
+  ::ng-deep .mat-drawer {
+    height: 100% !important;
+  }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,18 +1,25 @@
-<div class="content">
-  @if (this.tools.length === 0) {
-  <h2>No tools found</h2>
-  <p>There are no tools available for this project.</p>
-
-  } @else {
-  <mat-accordion multi="false">
-    @for (tool of this.tools; track tool) {
-    <mat-expansion-panel>
-      <mat-expansion-panel-header>
-        {{tool.name}}
-      </mat-expansion-panel-header>
-      <ng-template #viewContainer></ng-template>
-    </mat-expansion-panel>
-    }
-  </mat-accordion>
-  }
+<div class="home-container">
+  <mat-sidenav-container class="sidenav-container">
+    <mat-sidenav mode="side" opened>
+      <h2 class="sidenav-title">Engineering Toolkit</h2>
+      @if (this.tools.length === 0) {
+      <div class="no-tools-message">
+        <span>No tools available</span>
+      </div>
+      } @else {
+      <mat-nav-list>
+        @for (tool of this.tools; track tool) {
+        <a mat-list-item [class.active]="selectedTool?.name === tool.name" (click)="selectTool(tool)">
+          <span class="nav-label">{{tool.name}}</span>
+        </a>
+        }
+      </mat-nav-list>
+      }
+    </mat-sidenav>
+    <mat-sidenav-content>
+      <div class="tool-container">
+        <ng-template #toolContainer></ng-template>
+      </div>
+    </mat-sidenav-content>
+  </mat-sidenav-container>
 </div>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,50 +1,54 @@
-import { Component, ComponentFactoryResolver, QueryList, ViewChildren, ViewContainerRef } from '@angular/core';
+import { Component, ComponentFactoryResolver, QueryList, ViewChildren, ViewContainerRef, ViewChild, AfterViewInit } from '@angular/core';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatListModule } from '@angular/material/list';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { ToolRegistryService } from '../services/tool-registry.service';
-
 @Component({
   selector: 'app-home',
-  imports: [CommonModule, MatExpansionModule, HttpClientModule],
+  imports: [CommonModule, MatExpansionModule, HttpClientModule, MatSidenavModule, MatListModule],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css'
 })
-export class HomeComponent {
+export class HomeComponent implements AfterViewInit {
+  firstToolSelected: boolean = false;
   tools: Array<{ name: string, component: any }> = [];
-
-  @ViewChildren('viewContainer', { read: ViewContainerRef }) viewContainers!: QueryList<ViewContainerRef>;
+  selectedTool: { name: string, component: any } | null = null;
+  
+  @ViewChild('toolContainer', { read: ViewContainerRef, static: true }) toolContainer!: ViewContainerRef;
 
   constructor(
     private componentFactoryResolver: ComponentFactoryResolver,
     private http: HttpClient,
     private toolRegistry: ToolRegistryService
-  ) {
-  }
+  ) { }
 
   ngOnInit() {
     this.http.get<{ tools: any[] }>('config/all-tools.json').subscribe(config => {
       this.toolRegistry.getComponentsFromConfig(config.tools).then(toolComponents => {
-          this.tools = toolComponents;
-          this.viewContainers.forEach((viewContainer, index) => {
-            this.insertTool(this.tools[index], viewContainer);
-          });
-        });
-    });
-  }
-
-  insertTool(tool: any, viewContainer: ViewContainerRef): boolean {
-    const componentFactory = this.componentFactoryResolver.resolveComponentFactory(tool.component);
-    viewContainer.clear();
-    viewContainer.createComponent(componentFactory);
-    return true;
-  }
-
-  ngAfterViewInit() {
-    this.viewContainers.changes.subscribe(() => {
-      this.viewContainers.forEach((viewContainer, index) => {
-          this.insertTool(this.tools[index], viewContainer);
+        this.tools = toolComponents;
       });
     });
+    this.selectTool(this.tools[0]);
+  }
+
+  ngAfterViewInit(): void {
+    this.loadSelectedTool();
+  }
+
+  selectTool(tool: { name: string, component: any }) {
+    this.selectedTool = tool;
+    this.loadSelectedTool();
+  }
+
+  loadSelectedTool() {
+    if (this.selectedTool && this.toolContainer) {
+      setTimeout(() => {
+        const componentFactory = this.componentFactoryResolver.resolveComponentFactory(this.selectedTool!.component);
+        this.toolContainer.clear();
+        this.toolContainer.createComponent(componentFactory);
+      });
+    }
   }
 }


### PR DESCRIPTION
Updated home page to use an Angular Material sidenav instead of an accordion. Tried to group tools together too but selecting them this way was a bit trickier than just listing them each as their own nav list item.

Can't seem to fix an issue where a tool isn't rendered until a nav-item is actually clicked though. Played around with selecting a tool and rendering in ngAfterViewInit(), as well as displaying a placeholder message before a tool is selected, but couldn't get either method to work.